### PR TITLE
task/GOMOBILE-47942 - Obtener información de tags iFrames al pasear MasterList. HLS

### DIFF
--- a/GoSwiftyM3U8.podspec
+++ b/GoSwiftyM3U8.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Sergio Ortega" => "sergio.ortegamartinez@telefonica.com" }
   
-  s.ios.deployment_target = "12.0"
+  s.tvos.deployment_target = '14.0'
+  s.ios.deployment_target = '14.0'
   
   s.source = { :git => "https://github.com/Telefonica/go-swifty-m3u8.git", :tag => s.version.to_s }
   s.source_files = 'Sources/**/*.swift'

--- a/Sources/Models/Playlist/MasterPlaylist.swift
+++ b/Sources/Models/Playlist/MasterPlaylist.swift
@@ -33,6 +33,7 @@ public struct MasterPlaylistTags {
     public let sessionKeyTag: EXT_X_SESSION_KEY?
     public let mediaTags: [EXT_X_MEDIA]
     public let streamTags: [EXT_X_STREAM_INF]
+    public let iFrameTags: [EXT_X_I_FRAME_STREAM_INF]
 }
 
 /// `MasterPlaylistTagsBuilder` used to build `MasterPlaylistTags` object.
@@ -42,11 +43,14 @@ class MasterPlaylistTagsBuilder {
     var sessionKeyTag: EXT_X_SESSION_KEY? = nil
     var mediaTags = [EXT_X_MEDIA]()
     var streamTags = [EXT_X_STREAM_INF]()
+    var iFrameTags = [EXT_X_I_FRAME_STREAM_INF]()
     
     func build() -> MasterPlaylistTags? {
         return MasterPlaylistTags(versionTag: self.versionTag,
                                   sessionKeyTag: self.sessionKeyTag,
                                   mediaTags: self.mediaTags,
-                                  streamTags: self.streamTags)
+                                  streamTags: self.streamTags,
+                                  iFrameTags: self.iFrameTags)
     }
 }
+

--- a/Sources/Models/Playlist/Playlist.swift
+++ b/Sources/Models/Playlist/Playlist.swift
@@ -46,7 +46,8 @@ public enum PlaylistType: String {
                 EXT_X_MEDIA.self,
                 EXT_X_STREAM_INF.self,
                 EXT_X_SESSION_KEY.self,
-                EXT_X_VERSION.self
+                EXT_X_VERSION.self,
+                EXT_X_I_FRAME_STREAM_INF.self
             ]
         case .video, .audio, .subtitles:
             return [
@@ -61,3 +62,4 @@ public enum PlaylistType: String {
         }
     }
 }
+

--- a/Sources/Models/Playlist/Playlist.swift
+++ b/Sources/Models/Playlist/Playlist.swift
@@ -37,6 +37,7 @@ public enum PlaylistType: String {
     case video
     case audio
     case subtitles
+    case iframes
     
     /// The default handled tags for each playlist type, this is used a default by the parser.
     var handledTagTypes: [Tag.Type] {
@@ -58,6 +59,11 @@ public enum PlaylistType: String {
                 EXT_X_KEY.self,
                 EXT_X_ALLOW_CACHE.self,
                 EXT_X_MEDIA_SEQUENCE.self
+            ]
+        case .iframes:
+            return [
+                EXT_X_MEDIA.self,
+                EXT_X_I_FRAME_STREAM_INF.self
             ]
         }
     }

--- a/Sources/Models/Tags/Tags.swift
+++ b/Sources/Models/Tags/Tags.swift
@@ -292,3 +292,40 @@ public class EXT_X_SESSION_KEY: BaseAttributedTag {
         try super.init(text: text, tagType: tagType, extraParams: attributesExtraParams)
     }
 }
+
+
+/// Repesents `EXT-X-STREAM-INF` tag.
+public class EXT_X_I_FRAME_STREAM_INF: BaseAttributedTag {
+    override public class var tag: String { return "#EXT-X-I-FRAME-STREAM-INF:" }
+    
+    static let bandwidthAttributeKey = "BANDWIDTH"
+    static let programIdAttributeKey = "PROGRAM-ID"
+    static let uriAttributeKey = "URI"
+    
+    public var bandwidth: Int {
+        return Int(self.attributes[EXT_X_I_FRAME_STREAM_INF.bandwidthAttributeKey] ?? " ") ?? -1
+    }
+    
+    public var programId: Int? {
+        return Int(self.attributes[EXT_X_I_FRAME_STREAM_INF.programIdAttributeKey] ?? " ")
+    }
+    
+    public var uri: String? {
+        return self.attributes[EXT_X_I_FRAME_STREAM_INF.uriAttributeKey] ?? ""
+    }
+    
+    public required init(text: String, tagType: Tag.Type, extraParams: [String: Any]?) throws {
+        let attributesExtraParams: [String: Any] = [
+            TagParamsKeys.attributesCount: 2,
+            TagParamsKeys.attributesSeperator: ",",
+            TagParamsKeys.attributesExtrasToRemove: ["\""],
+            TagParamsKeys.attributesKeys: [
+                EXT_X_I_FRAME_STREAM_INF.bandwidthAttributeKey,
+                EXT_X_I_FRAME_STREAM_INF.uriAttributeKey
+            ]
+        ]
+        try super.init(text:text, tagType: tagType, extraParams: attributesExtraParams)
+    }
+}
+
+

--- a/Sources/Models/Tags/Tags.swift
+++ b/Sources/Models/Tags/Tags.swift
@@ -294,7 +294,7 @@ public class EXT_X_SESSION_KEY: BaseAttributedTag {
 }
 
 
-/// Repesents `EXT-X-STREAM-INF` tag.
+/// Repesents `EXT_X_I_FRAME_STREAM_INF` tag.
 public class EXT_X_I_FRAME_STREAM_INF: BaseAttributedTag {
     override public class var tag: String { return "#EXT-X-I-FRAME-STREAM-INF:" }
     

--- a/Sources/Models/Tags/Tags.swift
+++ b/Sources/Models/Tags/Tags.swift
@@ -17,32 +17,32 @@
 
 import Foundation
 
-/// Repesents `EXTM3U` tag.
+/// Represents `EXTM3U` tag.
 public class EXTM3U: BaseTag {
     override public class var tag: String { return "#EXTM3U" }
 }
 
-/// Repesents `EXT-X-INDEPENDENT-SEGMENTS` tag.
+/// Represents `EXT-X-INDEPENDENT-SEGMENTS` tag.
 public class EXT_X_INDEPENDENT_SEGMENTS: BaseTag {
     override public class var tag: String { return "#EXT-X-INDEPENDENT-SEGMENTS" }
 }
 
-/// Repesents `EXT-X-TARGETDURATION` tag.
+/// Represents `EXT-X-TARGETDURATION` tag.
 public class EXT_X_TARGETDURATION: BaseValueTag<Int> {
     override public class var tag: String { return "#EXT-X-TARGETDURATION:" }
 }
 
-/// Repesents `EXT-X-VERSION` tag.
+/// Represents `EXT-X-VERSION` tag.
 public class EXT_X_VERSION: BaseValueTag<Int> {
     override public class var tag: String { return "#EXT-X-VERSION:" }
 }
 
-/// Repesents `EXT-X-MEDIA-SEQUENCE` tag.
+/// Represents `EXT-X-MEDIA-SEQUENCE` tag.
 public class EXT_X_MEDIA_SEQUENCE: BaseValueTag<Int> {
     override public class var tag: String { return "#EXT-X-MEDIA-SEQUENCE:" }
 }
 
-/// Repesents a type with vod/event options.
+/// Represents a type with vod/event options.
 public enum PlaylistTagType: String , StringInitializable {
     
     case vod = "VOD", event = "EVENT"
@@ -52,12 +52,12 @@ public enum PlaylistTagType: String , StringInitializable {
     }
 }
 
-/// Repesents `EXT-X-PLAYLIST-TYPE` tag.
+/// Represents `EXT-X-PLAYLIST-TYPE` tag.
 public class EXT_X_PLAYLIST_TYPE: BaseValueTag<PlaylistTagType> {
     override public class var tag: String { return "#EXT-X-PLAYLIST-TYPE:" }
 }
 
-/// Repesents a type with yes/no options.
+/// Represents a type with yes/no options.
 public enum BoolTagType: String, StringInitializable {
     case yes = "YES", no = "NO"
     
@@ -66,17 +66,17 @@ public enum BoolTagType: String, StringInitializable {
     }
 }
 
-/// Repesents `EXT-X-ALLOW-CACHE` tag.
+/// Represents `EXT-X-ALLOW-CACHE` tag.
 public class EXT_X_ALLOW_CACHE: BaseValueTag<BoolTagType> {
     override public class var tag: String { return "#EXT-X-ALLOW-CACHE:" }
 }
 
-/// Repesents `EXT-X-BITRATE` tag.
+/// Represents `EXT-X-BITRATE` tag.
 public class EXT_X_BITRATE: BaseValueTag<Int> {
     override public class var tag: String { return "#EXT-X-BITRATE:" }
 }
 
-/// Repesents `EXTINF` tag.
+/// Represents `EXTINF` tag.
 public class EXTINF: BaseValueTag<Double>, MultilineTag {
     override public class var tag: String { return "#EXTINF:" }
     
@@ -120,7 +120,7 @@ public class EXTINF: BaseValueTag<Double>, MultilineTag {
     }
 }
 
-/// Repesents `EXT-X-KEY` tag.
+/// Represents `EXT-X-KEY` tag.
 public class EXT_X_KEY: BaseAttributedTag {
     override public class var tag: String { return "#EXT-X-KEY:" }
     
@@ -146,7 +146,7 @@ public class EXT_X_KEY: BaseAttributedTag {
     }
 }
 
-/// Repesents `EXT-X-STREAM-INF` tag.
+/// Represents `EXT-X-STREAM-INF` tag.
 public class EXT_X_STREAM_INF: BaseAttributedTag, MultilineTag {
     override public class var tag: String { return "#EXT-X-STREAM-INF:" }
     
@@ -194,7 +194,7 @@ public class EXT_X_STREAM_INF: BaseAttributedTag, MultilineTag {
     }
 }
 
-/// Repesents `EXT-X-MEDIA` tag.
+/// Represents `EXT-X-MEDIA` tag.
 public class EXT_X_MEDIA: BaseAttributedTag {
     override public class var tag: String { return "#EXT-X-MEDIA:" }
     /// Media type of `EXT-X-MEDIA` tag (audio/video/subtitles/cc/invalid)
@@ -252,7 +252,7 @@ public class EXT_X_MEDIA: BaseAttributedTag {
     }
 }
 
-/// Repesents `EXT-X-SESSION-KEY` tag.
+/// Represents `EXT-X-SESSION-KEY` tag.
 public class EXT_X_SESSION_KEY: BaseAttributedTag {
     override public class var tag: String { return "#EXT-X-SESSION-KEY:" }
     
@@ -294,7 +294,7 @@ public class EXT_X_SESSION_KEY: BaseAttributedTag {
 }
 
 
-/// Repesents `EXT_X_I_FRAME_STREAM_INF` tag.
+/// Represents `EXT_X_I_FRAME_STREAM_INF` tag.
 public class EXT_X_I_FRAME_STREAM_INF: BaseAttributedTag {
     override public class var tag: String { return "#EXT-X-I-FRAME-STREAM-INF:" }
     

--- a/Sources/Parser/M3U8Parser.swift
+++ b/Sources/Parser/M3U8Parser.swift
@@ -231,6 +231,9 @@ public class M3U8Parser {
         case is EXT_X_SESSION_KEY.Type:
             let sessionKeyTag = try tagType.init(text: line, tagType: EXT_X_SESSION_KEY.self, extraParams: nil) as? EXT_X_SESSION_KEY
             masterPlaylistTagsBuilder.sessionKeyTag = sessionKeyTag
+        case is EXT_X_I_FRAME_STREAM_INF.Type:
+            let iFrameTag = try tagType.init(text: line, tagType: EXT_X_I_FRAME_STREAM_INF.self, extraParams: nil) as! EXT_X_I_FRAME_STREAM_INF
+            masterPlaylistTagsBuilder.iFrameTags.append(iFrameTag)
         default: break
         }
     }

--- a/Sources/Parser/M3U8Parser.swift
+++ b/Sources/Parser/M3U8Parser.swift
@@ -140,7 +140,14 @@ public class M3U8Parser {
             let mediaPlaylist = MediaPlaylist(originalText: params.playlist, alteredText: alteredText, type: params.playlistType,
                                               baseUrl: params.baseUrl, tags: mediaPlaylistTags, extraTags: extraTags)
             return .media(mediaPlaylist)
+        case .iframes:
+            guard let masterPlaylistTags = masterPlaylistTagsBuilder.build() else {
+                throw Error.malformedPlaylist
+            }
+            return .master(MasterPlaylist(originalText: params.playlist, alteredText: alteredText,
+                                                    baseUrl: params.baseUrl, tags: masterPlaylistTags, extraTags: extraTags))
         }
+
     }
     
     /// cancels the parsing by changing isCancelled property to true.
@@ -166,7 +173,7 @@ public class M3U8Parser {
                 self.handleMultilineTag(tagType: tagType, on: &line, lineIndex: &lineIndex, lines: &lines)
                 // handle matched tag for master/media playlists
                 switch playlistType {
-                case .master:
+                case .master, .iframes:
                     try self.handleMasterPlaylistTags(line: line,
                                                       tagType: tagType,
                                                       masterPlaylistTagsBuilder: &masterPlaylistTagsBuilder)


### PR DESCRIPTION
https://jira.tid.es/browse/GOMOBILE-47942

## Respuesta

#EXTM3U
#--Created with VSPP Streamer version 6.0.7.2 build Commit_id: 4781a04aff6a2daac3b0c7668741de0de5fb4cb2 Commit_time: 1599472577 context DFHKJACAHKCDFKEG\n#-----------------------------------------------------------
▿ baseUrl : http://b43517-p1-h15-t3a81e8.1.cdn.telefonica.com/_43517/_-_eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlkyUnVPakUyT0RneU9EWTJNRE09In0.eyJpYXQiOjE2ODg0Njk1NzMsInVpZCI6IldKUG80U3VlSkdIVmk1M3F5NU5YX2tVdXZnRDBydWRLS1hoMDlnb1VRUWswRFF2MDZJVzlsVGg1YUNFVGZFd1cifQ.D8bDlfeFosPCEpDpmxhdSDpkpMyUSIcTa7NYm_kTff-dlBE60-ASXt4Ep_5Xdy7wWY09glp3sQAOQ96xjIzJ4A_-_/?start=LIVE&end=END&device=Hls&tcdn-bitrate-filter=Live-M

▿ tags : MasterPlaylistTags
- versionTag : nil
- sessionKeyTag : nil
▿ mediaTags : 1 element
- 0 : <EXT_X_MEDIA: 0x283428c30>
- streamTags : 0 elements
▿ iFrameTags : 7 elements
- 0 : <EXT_X_I_FRAME_STREAM_INF: 0x283429810>
- 1 : <EXT_X_I_FRAME_STREAM_INF: 0x283429c70>
- 2 : <EXT_X_I_FRAME_STREAM_INF: 0x283428eb0>
- 3 : <EXT_X_I_FRAME_STREAM_INF: 0x283429fe0>
- 4 : <EXT_X_I_FRAME_STREAM_INF: 0x283429360>
- 5 : <EXT_X_I_FRAME_STREAM_INF: 0x283429ea0>
- 6 : <EXT_X_I_FRAME_STREAM_INF: 0x2834295e0>

extraTags : 0 elements
## Información primer contenido iFrameTag

**URI**
"index.m3u8/S!dxIHVP7...8BNuFJt2cTR1ZQLUZhaXJwbGF5LURSTV9DTHgQ3QMUBBUBFwEYFK8_/Iframe(4190000)?start=LIVE&end=END"
**Bandwidth**
131218